### PR TITLE
setup.py: Fix install_requires for Python >=3.4

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Changes
 ?.?.? (????-??-??)
 =====================
 
+ - No longer depend on singledispatch for Python 3.4 and after
  - Drop support for Python 3.3 and 3.4
  - Add support for Python 3.5, 3.6, 3.7 and 3.8
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import sys
 import os
 import codecs
 from setuptools import setup
@@ -12,9 +11,9 @@ with codecs.open(
     long_description = ld_file.read()
 
 
-install_requires = []
-if sys.version_info[0] < 3 or sys.version_info[1] < 4:
-    install_requires.append('singledispatch')
+install_requires = [
+    'singledispatch; python_version<"3.4"',
+]
 
 setup (
     name = 'mergedict',


### PR DESCRIPTION
The way that `setup.py` pulls `singledispatch` into `install_requires`…

https://github.com/schettino72/mergedict/blob/0069fcd5381d2299a50a5463a3f02565fbeef496/setup.py#L15-L17

… does not work for Python 3.4, as can be seen here:

```console
# cd "$(mktemp -d)"

# virtualenv --python=python3.7 py37
[..]

# source py37/bin/activate
# pip install mergedict
Processing /home/user/.cache/pip/wheels/36/d4/87/7f9efc964baf0d177b4c477a4d19c52273e50aaec38e5952c8/mergedict-0.2.0-cp37-none-any.whl
Collecting singledispatch  <---
  Using cached singledispatch-3.4.0.3-py2.py3-none-any.whl (12 kB)
Collecting six
  Using cached six-1.14.0-py2.py3-none-any.whl (10 kB)
Installing collected packages: six, singledispatch, mergedict
Successfully installed mergedict-0.2.0 singledispatch-3.4.0.3 six-1.14.0

# python -c 'import mergedict, sys; print(sys.version_info[:2])'
(3, 7)

# pip freeze
mergedict==0.2.0
singledispatch==3.4.0.3  <--- should not be installed
six==1.14.0
```

This pull request provides a fix.